### PR TITLE
release: v1.0.48

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -139,16 +139,16 @@
         },
         {
             "name": "wp-content-framework/presenter",
-            "version": "v1.0.36",
+            "version": "v1.0.37",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-content-framework/presenter.git",
-                "reference": "914abf3e3fe61e864af8172d8e94c5d5dc3071f3"
+                "reference": "6c959c437b169a58e1ecb506ef21bf169be73bce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-content-framework/presenter/zipball/914abf3e3fe61e864af8172d8e94c5d5dc3071f3",
-                "reference": "914abf3e3fe61e864af8172d8e94c5d5dc3071f3",
+                "url": "https://api.github.com/repos/wp-content-framework/presenter/zipball/6c959c437b169a58e1ecb506ef21bf169be73bce",
+                "reference": "6c959c437b169a58e1ecb506ef21bf169be73bce",
                 "shasum": ""
             },
             "require": {
@@ -182,7 +182,7 @@
             ],
             "support": {
                 "issues": "https://github.com/wp-content-framework/presenter/issues",
-                "source": "https://github.com/wp-content-framework/presenter/tree/v1.0.36"
+                "source": "https://github.com/wp-content-framework/presenter/tree/v1.0.37"
             },
             "funding": [
                 {
@@ -190,7 +190,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2021-03-15T05:10:59+00:00"
+            "time": "2021-03-29T05:52:27+00:00"
         }
     ],
     "packages-dev": [
@@ -874,16 +874,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v5.2.5",
+            "version": "v5.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "be0c7926f5729b15e4e79fd2bf917cac584b1970"
+                "reference": "1e66194bed2a69fa395d26bf1067e5e34483afac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/be0c7926f5729b15e4e79fd2bf917cac584b1970",
-                "reference": "be0c7926f5729b15e4e79fd2bf917cac584b1970",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/1e66194bed2a69fa395d26bf1067e5e34483afac",
+                "reference": "1e66194bed2a69fa395d26bf1067e5e34483afac",
                 "shasum": ""
             },
             "require": {
@@ -941,7 +941,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v5.2.5"
+                "source": "https://github.com/symfony/dependency-injection/tree/v5.2.6"
             },
             "funding": [
                 {
@@ -957,7 +957,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-05T20:13:41+00:00"
+            "time": "2021-03-22T11:10:24+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -1028,16 +1028,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.2.4",
+            "version": "v5.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "710d364200997a5afde34d9fe57bd52f3cc1e108"
+                "reference": "8c86a82f51658188119e62cff0a050a12d09836f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/710d364200997a5afde34d9fe57bd52f3cc1e108",
-                "reference": "710d364200997a5afde34d9fe57bd52f3cc1e108",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/8c86a82f51658188119e62cff0a050a12d09836f",
+                "reference": "8c86a82f51658188119e62cff0a050a12d09836f",
                 "shasum": ""
             },
             "require": {
@@ -1070,7 +1070,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.2.4"
+                "source": "https://github.com/symfony/filesystem/tree/v5.2.6"
             },
             "funding": [
                 {
@@ -1086,7 +1086,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-12T10:38:38+00:00"
+            "time": "2021-03-28T14:30:26+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update dependencies (ee05ea7647bf32bbd2a06901385c8e4ec456604e)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/wp-content-framework/controller/tree/master)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>composer prepare</em></summary>

```Shell
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/php-compatibility,../../phpcompatibility/phpcompatibility-paragonie,../../phpcompatibility/phpcompatibility-wp,../../wp-coding-standards/wpcs

>> Copy files.
>>>> phpmd.xml
>>>> phpcs.xml
```

### stderr:

```Shell
> mkdir -p ./fixtures/.git
> chmod -R +w ./fixtures/.git && rm -rdf ./fixtures
> rm -f ./phpcs.xml ./phpmd.xml ./phpunit.xml
> git clone --depth=1 https://github.com/wp-content-framework/fixtures.git fixtures
Cloning into 'fixtures'...
> WORKSPACE=${WORKSPACE:-$(cd $(dirname $0); pwd)} bash ./fixtures/bin/prepare.sh
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^0.7.1 for dealerdirect/phpcodesniffer-composer-installer
Using version ^2.9 for phpmd/phpmd
Using version ^3.5 for squizlabs/php_codesniffer
Using version ^2.3 for wp-coding-standards/wpcs
Using version ^2.1 for phpcompatibility/phpcompatibility-wp
./composer.json has been updated
Running composer update dealerdirect/phpcodesniffer-composer-installer phpmd/phpmd squizlabs/php_codesniffer wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp
Loading composer repositories with package information
Updating dependencies
Lock file operations: 21 installs, 0 updates, 0 removals
  - Locking composer/xdebug-handler (1.4.6)
  - Locking dealerdirect/phpcodesniffer-composer-installer (v0.7.1)
  - Locking matthiasmullie/minify (1.3.66)
  - Locking matthiasmullie/path-converter (1.1.3)
  - Locking pdepend/pdepend (2.9.0)
  - Locking phpcompatibility/php-compatibility (9.3.5)
  - Locking phpcompatibility/phpcompatibility-paragonie (1.3.1)
  - Locking phpcompatibility/phpcompatibility-wp (2.1.1)
  - Locking phpmd/phpmd (2.9.1)
  - Locking psr/container (1.1.1)
  - Locking psr/log (1.1.3)
  - Locking squizlabs/php_codesniffer (3.5.8)
  - Locking symfony/config (v5.2.4)
  - Locking symfony/dependency-injection (v5.2.6)
  - Locking symfony/deprecation-contracts (v2.2.0)
  - Locking symfony/filesystem (v5.2.6)
  - Locking symfony/polyfill-ctype (v1.22.1)
  - Locking symfony/polyfill-php80 (v1.22.1)
  - Locking symfony/service-contracts (v2.2.0)
  - Locking wp-coding-standards/wpcs (2.3.0)
  - Locking wp-content-framework/presenter (v1.0.37)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 21 installs, 0 updates, 0 removals
  - Downloading squizlabs/php_codesniffer (3.5.8)
  - Downloading dealerdirect/phpcodesniffer-composer-installer (v0.7.1)
  - Downloading matthiasmullie/path-converter (1.1.3)
  - Downloading phpcompatibility/php-compatibility (9.3.5)
  - Downloading phpcompatibility/phpcompatibility-paragonie (1.3.1)
  - Downloading phpcompatibility/phpcompatibility-wp (2.1.1)
  - Downloading symfony/polyfill-ctype (v1.22.1)
  - Downloading symfony/filesystem (v5.2.6)
  - Downloading psr/container (1.1.1)
  - Downloading symfony/service-contracts (v2.2.0)
  - Downloading symfony/polyfill-php80 (v1.22.1)
  - Downloading symfony/deprecation-contracts (v2.2.0)
  - Downloading symfony/dependency-injection (v5.2.6)
  - Downloading symfony/config (v5.2.4)
  - Downloading pdepend/pdepend (2.9.0)
  - Downloading psr/log (1.1.3)
  - Downloading composer/xdebug-handler (1.4.6)
  - Downloading phpmd/phpmd (2.9.1)
  - Downloading wp-coding-standards/wpcs (2.3.0)
  - Downloading matthiasmullie/minify (1.3.66)
  - Downloading wp-content-framework/presenter (v1.0.37)
  0/21 [>---------------------------]   0%
  5/21 [======>---------------------]  23%
 10/21 [=============>--------------]  47%
 13/21 [=================>----------]  61%
 18/21 [========================>---]  85%
 20/21 [==========================>-]  95%
 21/21 [============================] 100%  - Installing squizlabs/php_codesniffer (3.5.8): Extracting archive
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.7.1): Extracting archive
  - Installing matthiasmullie/path-converter (1.1.3): Extracting archive
  - Installing phpcompatibility/php-compatibility (9.3.5): Extracting archive
  - Installing phpcompatibility/phpcompatibility-paragonie (1.3.1): Extracting archive
  - Installing phpcompatibility/phpcompatibility-wp (2.1.1): Extracting archive
  - Installing symfony/polyfill-ctype (v1.22.1): Extracting archive
  - Installing symfony/filesystem (v5.2.6): Extracting archive
  - Installing psr/container (1.1.1): Extracting archive
  - Installing symfony/service-contracts (v2.2.0): Extracting archive
  - Installing symfony/polyfill-php80 (v1.22.1): Extracting archive
  - Installing symfony/deprecation-contracts (v2.2.0): Extracting archive
  - Installing symfony/dependency-injection (v5.2.6): Extracting archive
  - Installing symfony/config (v5.2.4): Extracting archive
  - Installing pdepend/pdepend (2.9.0): Extracting archive
  - Installing psr/log (1.1.3): Extracting archive
  - Installing composer/xdebug-handler (1.4.6): Extracting archive
  - Installing phpmd/phpmd (2.9.1): Extracting archive
  - Installing wp-coding-standards/wpcs (2.3.0): Extracting archive
  - Installing matthiasmullie/minify (1.3.66): Extracting archive
  - Installing wp-content-framework/presenter (v1.0.37): Extracting archive
 0/9 [>---------------------------]   0%
 9/9 [============================] 100%
 9/9 [============================] 100%9 package suggestions were added by new dependencies, use `composer suggest` to see details.
Generating autoload files
12 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^1.0 for wp-content-framework/presenter
./composer.json has been updated
Running composer update wp-content-framework/presenter
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
Generating autoload files
12 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Nothing to install, update or remove
Generating autoload files
12 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

</details>
<details>
<summary><em>composer packages</em></summary>

```Shell
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/php-compatibility,../../phpcompatibility/phpcompatibility-paragonie,../../phpcompatibility/phpcompatibility-wp,../../wp-coding-standards/wpcs
```

### stderr:

```Shell
> WORKSPACE=${WORKSPACE:-$(cd $(dirname $0); pwd)} bash ./fixtures/bin/packages.sh
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^0.7.1 for dealerdirect/phpcodesniffer-composer-installer
Using version ^2.9 for phpmd/phpmd
Using version ^3.5 for squizlabs/php_codesniffer
Using version ^2.3 for wp-coding-standards/wpcs
Using version ^2.1 for phpcompatibility/phpcompatibility-wp
./composer.json has been updated
Running composer update dealerdirect/phpcodesniffer-composer-installer phpmd/phpmd squizlabs/php_codesniffer wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp
Loading composer repositories with package information
Updating dependencies
Lock file operations: 21 installs, 0 updates, 0 removals
  - Locking composer/xdebug-handler (1.4.6)
  - Locking dealerdirect/phpcodesniffer-composer-installer (v0.7.1)
  - Locking matthiasmullie/minify (1.3.66)
  - Locking matthiasmullie/path-converter (1.1.3)
  - Locking pdepend/pdepend (2.9.0)
  - Locking phpcompatibility/php-compatibility (9.3.5)
  - Locking phpcompatibility/phpcompatibility-paragonie (1.3.1)
  - Locking phpcompatibility/phpcompatibility-wp (2.1.1)
  - Locking phpmd/phpmd (2.9.1)
  - Locking psr/container (1.1.1)
  - Locking psr/log (1.1.3)
  - Locking squizlabs/php_codesniffer (3.5.8)
  - Locking symfony/config (v5.2.4)
  - Locking symfony/dependency-injection (v5.2.6)
  - Locking symfony/deprecation-contracts (v2.2.0)
  - Locking symfony/filesystem (v5.2.6)
  - Locking symfony/polyfill-ctype (v1.22.1)
  - Locking symfony/polyfill-php80 (v1.22.1)
  - Locking symfony/service-contracts (v2.2.0)
  - Locking wp-coding-standards/wpcs (2.3.0)
  - Locking wp-content-framework/presenter (v1.0.37)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 21 installs, 0 updates, 0 removals
    0 [>---------------------------]    0 [>---------------------------]    0 [>---------------------------]  - Installing squizlabs/php_codesniffer (3.5.8): Extracting archive
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.7.1): Extracting archive
  - Installing matthiasmullie/path-converter (1.1.3): Extracting archive
  - Installing phpcompatibility/php-compatibility (9.3.5): Extracting archive
  - Installing phpcompatibility/phpcompatibility-paragonie (1.3.1): Extracting archive
  - Installing phpcompatibility/phpcompatibility-wp (2.1.1): Extracting archive
  - Installing symfony/polyfill-ctype (v1.22.1): Extracting archive
  - Installing symfony/filesystem (v5.2.6): Extracting archive
  - Installing psr/container (1.1.1): Extracting archive
  - Installing symfony/service-contracts (v2.2.0): Extracting archive
  - Installing symfony/polyfill-php80 (v1.22.1): Extracting archive
  - Installing symfony/deprecation-contracts (v2.2.0): Extracting archive
  - Installing symfony/dependency-injection (v5.2.6): Extracting archive
  - Installing symfony/config (v5.2.4): Extracting archive
  - Installing pdepend/pdepend (2.9.0): Extracting archive
  - Installing psr/log (1.1.3): Extracting archive
  - Installing composer/xdebug-handler (1.4.6): Extracting archive
  - Installing phpmd/phpmd (2.9.1): Extracting archive
  - Installing wp-coding-standards/wpcs (2.3.0): Extracting archive
  - Installing matthiasmullie/minify (1.3.66): Extracting archive
  - Installing wp-content-framework/presenter (v1.0.37): Extracting archive
 0/9 [>---------------------------]   0%
 8/9 [========================>---]  88%
 9/9 [============================] 100%9 package suggestions were added by new dependencies, use `composer suggest` to see details.
Generating autoload files
12 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^1.0 for wp-content-framework/presenter
./composer.json has been updated
Running composer update wp-content-framework/presenter
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
Generating autoload files
12 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- composer.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)